### PR TITLE
Update to Julia v0.7+

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,121 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[CodeTracking]]
+deps = ["InteractiveUtils", "UUIDs"]
+git-tree-sha1 = "9aa8a5ebb6b5bf469a7e0e2b5202cf6f8c291104"
+uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
+version = "1.0.6"
+
+[[Crayons]]
+git-tree-sha1 = "3f71217b538d7aaee0b69ab47d9b7724ca8afa0d"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.0.4"
+
+[[DataStructures]]
+deps = ["InteractiveUtils", "OrderedCollections", "Random", "Serialization", "Test"]
+git-tree-sha1 = "e5bf54defdcdbd51e5a61fe0fe2ee9a7d428b36c"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.16.1"
+
+[[Debugger]]
+deps = ["CodeTracking", "Crayons", "Highlights", "InteractiveUtils", "JuliaInterpreter", "Markdown", "REPL"]
+git-tree-sha1 = "314642620f95fca224d578ec615b944b5e5ee6db"
+uuid = "31a5f54b-26ea-5ae9-a837-f05ce5417438"
+version = "0.6.8"
+
+[[Distances]]
+deps = ["LinearAlgebra", "Printf", "Random", "Statistics", "Test"]
+git-tree-sha1 = "a135c7c062023051953141da8437ed74f89d767a"
+uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+version = "0.8.0"
+
+[[DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.8.6"
+
+[[Highlights]]
+deps = ["DocStringExtensions", "InteractiveUtils", "REPL"]
+git-tree-sha1 = "f823a2d04fb233d52812c8024a6d46d9581904a4"
+uuid = "eafb193a-b7ab-5a9e-9068-77385905fa72"
+version = "0.4.5"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JuliaInterpreter]]
+deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
+git-tree-sha1 = "e273807f38074f033d94207a201e6e827d8417db"
+uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
+version = "0.8.21"
+
+[[LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[OrderedCollections]]
+git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.4.1"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,12 @@
+name = "EMST"
+uuid = "26b6d932-1723-494d-aa9d-2874a775a9f7"
+authors = ["Thomas Liphardt <liphardtt@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+Debugger = "31a5f54b-26ea-5ae9-a837-f05ce5417438"
+Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/emst_dual_boruvka.jl
+++ b/src/emst_dual_boruvka.jl
@@ -1,6 +1,7 @@
 
 using DataStructures
 using Distances
+using Statistics
 
 import Base.isequal
 import Base.hash
@@ -34,7 +35,7 @@ function hash(a::MyE)
     return xor( hash(a.a) , hash(a.b) )
 end
 function to_matrix(ee::Vector{MyE})
-    m::Array{Int64,2} = Array{Int64}(length(ee),2)
+    m::Array{Int64,2} = Array{Int64}(undef, length(ee),2)
     for zi=1:length(ee); m[zi,1] = ee[zi].a; m[zi,2] = ee[zi].b; end
     return m
 end
@@ -129,10 +130,10 @@ function kdtree_split!( node::DTBNode, nmin::Int64)
         return node
     end
 
-    mind = minimum(node.data,2)
-    maxd = maximum(node.data,2)
+    mind = minimum(node.data, dims=2)
+    maxd = maximum(node.data, dims=2)
     ds   = findmax( maxd-mind )
-    ds   = ds[2]
+    ds   = ds[2][1]
     #println("$ds")
     vs   = median(node.data[ds,:])
     #println("$vs")
@@ -263,7 +264,7 @@ function fcn(q::DTBNode,r::DTBNode,e::IntDisjointSets , C_dcq::Dict{Int64,Float6
         #n_dQ = -Inf
         n_dQ::Float64 = q.dQ
 
-        all_d_qr = Distances.pairwise(Euclidean(),q.data,r.data)
+        all_d_qr = Distances.pairwise(Euclidean(),q.data,r.data, dims = 2)
 
         # --> hashing these values does not really speed up things..
         #     and it uses tons of memory, such that fancier handling of

--- a/src/emst_validation.jl
+++ b/src/emst_validation.jl
@@ -1,3 +1,4 @@
+using Random
 
 
 """
@@ -26,9 +27,9 @@ function verify_emst(x::Array{Float64,2},e::Array{Int64,2},idx_check::Vector{Int
     ok = true
     for zi in 1:length(idx_check)
         ix = idx_check[zi]
-        xd = sum( ( broadcast(-,x[:,ix],x) ).^2 , 1 )
+        xd = sum( ( broadcast(-,x[:,ix],x) ).^2 , dims=1 )
         xd[ix] = Inf
-        i_min = findmin(xd)[2]
+        i_min = findmin(xd)[2][2]
         if( sum( xd.==xd[i_min] )>1 )
             println("WARNING: Equidistant vertices discovered..")
             ok=false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@
 ##
 #reload("EMST.jl")
 using EMST
+using Random
+
 @static if VERSION < v"0.7.0-DEV.2005"
     using Base.Test
 else


### PR DESCRIPTION
Thank you for making this code open.

This pull request is to make it run with later versions of Julia.

- Create project and manifest files.
- Load the Statistics module for `median()` and the Random module for `randperm()`, which are no longer in Base.
- Declare the `undef` data type when initialising an `Array`.
- Name the `dims` argument of `minimum()`, `maximum()`, `pairwise()` and `sum()`.
- Subset the Cartesian index now returned by `findmax()` and `findmin()`.